### PR TITLE
PHP 8 Type Bug Fix

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -1014,7 +1014,7 @@ class MWSClient
         $response = $this->request(
             'SubmitFeed',
             $query,
-            $feedContent
+            $feedContent->toString()
         );
 
         return $response['SubmitFeedResult']['FeedSubmissionInfo'];


### PR DESCRIPTION
MD5 expects string, ```feedCOntent``` previously was auto using the __toString() method; however now its failing at MD5 param input check, thus needs to be a string before hitting MD5 function